### PR TITLE
Update for 1.21.x

### DIFF
--- a/CakeBuild/CakeBuild.csproj
+++ b/CakeBuild/CakeBuild.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
 
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <Reference Include="VintagestoryAPI">
-      <HintPath>$(VINTAGE_STORY)/1.20.x/VintagestoryAPI.dll</HintPath>
+      <HintPath>$(VINTAGE_STORY)/1.21.x/VintagestoryAPI.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/HandsomeTweaks/HandsomeTweaks.csproj
+++ b/HandsomeTweaks/HandsomeTweaks.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>bin\$(Configuration)\Mods\mod</OutputPath>
+		<LangVersion>default</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -13,27 +14,27 @@
 	<!-- Core dependencies -->
 	<ItemGroup>
 		<Reference Include="VintagestoryAPI">
-			<HintPath>$(VINTAGE_STORY)/1.20.x/VintagestoryAPI.dll</HintPath>
+			<HintPath>$(VINTAGE_STORY)/1.21.x/VintagestoryAPI.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="VSEssentials">
-			<HintPath>$(VINTAGE_STORY)/1.20.x/Mods/VSEssentials.dll</HintPath>
+			<HintPath>$(VINTAGE_STORY)/1.21.x/Mods/VSEssentials.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="VSSurvivalMod">
-			<HintPath>$(VINTAGE_STORY)/1.20.x/Mods/VSSurvivalMod.dll</HintPath>
+			<HintPath>$(VINTAGE_STORY)/1.21.x/Mods/VSSurvivalMod.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="0Harmony">
-			<HintPath>$(VINTAGE_STORY)/1.20.x/Lib/0Harmony.dll</HintPath>
+			<HintPath>$(VINTAGE_STORY)/1.21.x/Lib/0Harmony.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="cairo-sharp">
-			<HintPath>$(VINTAGE_STORY)/1.20.x/Lib/cairo-sharp.dll</HintPath>
+			<HintPath>$(VINTAGE_STORY)/1.21.x/Lib/cairo-sharp.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="Newtonsoft.Json">
-			<HintPath>$(VINTAGE_STORY)/1.20.x/Lib/Newtonsoft.Json.dll</HintPath>
+			<HintPath>$(VINTAGE_STORY)/1.21.x/Lib/Newtonsoft.Json.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 	</ItemGroup>
@@ -42,13 +43,7 @@
 	<ItemGroup>
 		<!-- For level up notification -->
 		<Reference Include="XLib">
-			<HintPath>$(VINTAGE_STORY_DEV_MODS)/1.20.x/xlib/xlib.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-
-		<!-- For saucepan tweaks -->
-		<Reference Include="ACulinaryArtillery">
-			<HintPath>$(VINTAGE_STORY_DEV_MODS)/1.20.x/ACulinaryArtillery/ACulinaryArtillery.dll</HintPath>
+			<HintPath>../../lib/xlib/xlib.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 	</ItemGroup>

--- a/HandsomeTweaks/Modules/CulinaryTweaks/Patches/BlockPatch.cs
+++ b/HandsomeTweaks/Modules/CulinaryTweaks/Patches/BlockPatch.cs
@@ -1,7 +1,4 @@
-using ACulinaryArtillery;
-
 using HarmonyLib;
-
 using Vintagestory.API.Common;
 using Vintagestory.GameContent;
 
@@ -41,7 +38,8 @@ public static class BlockPatch {
 		if (__instance is BlockFirepit @this && @this.Stage == 5) {
 			var blockEntity = world.BlockAccessor.GetBlockEntity(blockSel.Position);
 			var itemStack = byPlayer.InventoryManager.ActiveHotbarSlot?.Itemstack;
-			if (blockEntity is BlockEntityFirepit beFirepit && itemStack?.Collectible is BlockSaucepan) {
+			var isSaucepan = itemStack?.Collectible.Class == "BlockSaucepan";
+			if (blockEntity is BlockEntityFirepit beFirepit && isSaucepan) {
 				// Try to put the saucepan to the input slot. The active hotbar
 				// slot is guaranteed to be non-null, as itemstack was already
 				// validated to be holding a saucepan.

--- a/HandsomeTweaks/Modules/FirepitTweaks/Patches/BlockFirepitPatch.cs
+++ b/HandsomeTweaks/Modules/FirepitTweaks/Patches/BlockFirepitPatch.cs
@@ -15,8 +15,8 @@ public static class BlockFirepitPatch {
 	public static void OnLoadedPostfix(BlockFirepit __instance, ref WorldInteraction[] ___interactions, ICoreAPI api) {
 		var insertableStacks = ObjectCacheUtil.GetOrCreate(api, "handsometweaks:firepittweaks-firepitInsertableStacks", () => {
 			var stacks = new ItemStack[] {
-				new(api.World.GetBlock("game:claypot-burned")),
-				new(api.World.GetBlock("game:crucible-burned")),
+				new(api.World.GetBlock("game:claypot-blue-fired")),
+				new(api.World.GetBlock("game:crucible-blue-fired")),
 			};
 			if (api.ModLoader.IsModSystemEnabled(typeof(CulinaryTweaks.CulinaryTweaks).FullName)) {
 				stacks = stacks.Append(

--- a/HandsomeTweaks/modinfo.json
+++ b/HandsomeTweaks/modinfo.json
@@ -3,14 +3,14 @@
 	"modid": "handsometweaks",
 	"name": "Handsome Tweaks",
 	"authors": [ "Jakojäännös", "ritinae" ],
-	"contributors": [ "Handsome Dogs" ],
+	"contributors": [ "Handsome Dogs", "LambdaSix" ],
 	"description": "Various tweaks and improvements to small gripes encountered while playing.",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"networkVersion": "1.0.0",
 	"side": "universal",
 	"requiredOnClient": true,
 	"requiredOnServer": true,
 	"dependencies": {
-		"game": "1.20.12"
+		"game": "1.21.1"
 	}
 }


### PR DESCRIPTION
- Remove reference to ACA library
- Retarget to .NET8
- Build against 1.21.x API
- Update string references to game: crucible & claypot